### PR TITLE
Fix import side effects

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,10 +83,11 @@ def przeszukaj_sklepy():
     else:
         wyslij_powiadomienie("Nie znaleziono nowych promocji Old Spice.")
 
-# Harmonogram â codziennie o 9:00
+# Harmonogram - codziennie o 9:00
 schedule.every().day.at("09:00").do(przeszukaj_sklepy)
 
-print("Bot do szukania promocji uruchomiony.")
-while True:
-    schedule.run_pending()
-    time.sleep(60)
+if __name__ == "__main__":
+    print("Bot do szukania promocji uruchomiony.")
+    while True:
+        schedule.run_pending()
+        time.sleep(60)


### PR DESCRIPTION
## Summary
- clean up comment encoding
- wrap script execution in a `__main__` guard

## Testing
- `python -m py_compile main.py`
- `python - <<'EOF'
from main import szukaj_rossmann
print('running rossmann')
print('function docs:', szukaj_rossmann.__name__)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6845a74720748331a2ac0bfdc1d70329